### PR TITLE
감정분석 기능 구현(측정/저장)

### DIFF
--- a/lib/main_screen.dart
+++ b/lib/main_screen.dart
@@ -12,6 +12,7 @@ import 'package:untitled/services/firestore_service.dart'; // Import moved here
 import 'emotion_tracking_tab.dart';
 import 'healing_screen.dart';
 import 'diagnosis_screen.dart';
+import 'mood_detail_questions_screen.dart';
 
 // --- Color Definitions ---
 const Color kColorBgStart = Color(0xFFEFF6FF);
@@ -34,6 +35,8 @@ const Color kColorEmergencyCardBg = Color(0xFFFEE2E2); // 긴급 상황 카드 �
 const Color kColorEmergencyBtnText = Color(0xFFEF4444); // 긴급 버튼 텍스트 (진한 빨강)
 const Color kColorEmergencyBtnBorder = Color(0xFFEF4444); // 긴급 버튼 테두리 (진한 빨강)
 const Color kColorBottomNavInactive = Color(0xFF9CA3AF); // 하단바 비활성 아이콘/텍스트
+
+bool _isMoodSelected = false;
 
 // CSV 텍스트 데이터 (동일)
 final Map<String, String> kTexts = {
@@ -442,7 +445,7 @@ class _HomeScreenContentState extends State<_HomeScreenContent> {
                 inactiveTrackColor: kColorMoodSliderInactive,
                 thumbShape: const RoundSliderThumbShape(enabledThumbRadius: 8.0),
                 thumbColor: kColorBtnPrimary,
-                overlayColor: kColorBtnPrimary.withOpacity(0.2), // ignore: deprecated_member_use
+                overlayColor: kColorBtnPrimary.withOpacity(0.2),
                 overlayShape: const RoundSliderOverlayShape(overlayRadius: 16.0),
                 valueIndicatorShape: const PaddleSliderValueIndicatorShape(),
                 valueIndicatorColor: kColorBtnPrimary,
@@ -459,9 +462,9 @@ class _HomeScreenContentState extends State<_HomeScreenContent> {
                 value: _currentMoodValue,
                 label: _currentMoodValue.round().toString(),
                 onChanged: (value) {
-                  // [!!] 이 위젯(_HomeScreenContent)의 상태를 업데이트
                   setState(() {
                     _currentMoodValue = value;
+                    _isMoodSelected = true; // 슬라이더를 움직였다는 표시
                   });
                 },
               ),
@@ -477,23 +480,23 @@ class _HomeScreenContentState extends State<_HomeScreenContent> {
             ),
             const SizedBox(height: 24.0),
             ElevatedButton(
-              onPressed: _currentUserId == null
-                  ? null // Disable button if no user is logged in
-                  : () async {
-                if (_currentUserId != null) {
-                  await _firestoreService.updateMoodScore(
-                      _currentUserId!, _currentMoodValue.round());
-                  ScaffoldMessenger.of(context).showSnackBar(
-                    const SnackBar(content: Text('기분 점수가 저장되었습니다!')), 
-                  );
-                } else {
-                  ScaffoldMessenger.of(context).showSnackBar(
-                    const SnackBar(content: Text('로그인이 필요합니다.')),
-                  );
-                }
+              onPressed: (_currentUserId == null || !_isMoodSelected)
+                  ? null  // 로그인 안 했거나 기분을 선택하지 않으면 비활성화
+                  : () {
+                // 기분 분석 상세 질문 화면으로 이동
+                Navigator.push(
+                  context,
+                  MaterialPageRoute(
+                    builder: (context) => MoodDetailQuestionsScreen(
+                      moodScore: _currentMoodValue.round(),
+                      userId: _currentUserId!,
+                    ),
+                  ),
+                );
               },
               style: ElevatedButton.styleFrom(
                 backgroundColor: kColorBtnPrimary,
+                disabledBackgroundColor: Colors.grey[300], // 비활성화 시 색상
                 shape: RoundedRectangleBorder(
                   borderRadius: BorderRadius.circular(12.0),
                 ),
@@ -502,7 +505,9 @@ class _HomeScreenContentState extends State<_HomeScreenContent> {
               child: Text(
                 kTexts['mood_analyze_button']!,
                 style: GoogleFonts.roboto(
-                  color: Colors.white,
+                  color: (_currentUserId == null || !_isMoodSelected)
+                      ? Colors.grey[600]
+                      : Colors.white,
                   fontSize: 14,
                   fontWeight: FontWeight.bold,
                 ),

--- a/lib/mood_detail_questions_screen.dart
+++ b/lib/mood_detail_questions_screen.dart
@@ -1,0 +1,502 @@
+import 'package:flutter/material.dart';
+import 'package:google_fonts/google_fonts.dart';
+import 'services/firestore_service.dart';
+
+class MoodDetailQuestionsScreen extends StatefulWidget {
+  final int moodScore;
+  final String userId;
+
+  const MoodDetailQuestionsScreen({
+    Key? key,
+    required this.moodScore,
+    required this.userId,
+  }) : super(key: key);
+
+  @override
+  State<MoodDetailQuestionsScreen> createState() =>
+      _MoodDetailQuestionsScreenState();
+}
+
+class _MoodDetailQuestionsScreenState extends State<MoodDetailQuestionsScreen> {
+  final FirestoreService _firestoreService = FirestoreService();
+  final Map<String, Map<String, dynamic>> _answers = {}; // 답변과 점수를 함께 저장
+  bool _isSubmitting = false;
+
+  // 색상 상수 (main_screen.dart와 동일하게 사용)
+  static const Color kColorBtnPrimary = Color(0xFF6B4EFF);
+  static const Color kColorCardBg = Colors.white;
+  static const Color kColorTextTitle = Color(0xFF2D3142);
+  static const Color kColorTextSubtitle = Color(0xFF7D8CA3);
+
+  List<Map<String, dynamic>> _getQuestions() {
+    // 기분 점수에 따라 다른 질문 반환
+    if (widget.moodScore >= 1 && widget.moodScore <= 3) {
+      // 부정적인 기분 (1-3점)
+      return [
+        {
+          'id': 'negative_reason',
+          'question': '오늘 기분이 좋지 않은 가장 큰 이유는 무엇인가요?',
+          'options': [
+            {'text': '업무/학업 스트레스', 'score': 1},
+            {'text': '대인관계 문제', 'score': 2},
+            {'text': '건강/신체 문제', 'score': 3},
+            {'text': '경제적 어려움', 'score': 2},
+            {'text': '미래에 대한 불안', 'score': 1},
+          ]
+        },
+        {
+          'id': 'negative_intensity',
+          'question': '이런 감정이 얼마나 오래 지속되었나요?',
+          'options': [
+            {'text': '오늘 처음 느꼈어요', 'score': 4},
+            {'text': '2-3일 정도', 'score': 3},
+            {'text': '일주일 정도', 'score': 2},
+            {'text': '2주 이상', 'score': 1},
+          ]
+        },
+        {
+          'id': 'negative_physical',
+          'question': '신체적으로 느끼는 증상이 있나요?',
+          'options': [
+            {'text': '수면 문제 (불면증/과수면)', 'score': 1},
+            {'text': '식욕 변화', 'score': 2},
+            {'text': '두통이나 몸의 통증', 'score': 2},
+            {'text': '특별한 증상 없음', 'score': 4},
+          ]
+        },
+        {
+          'id': 'negative_help',
+          'question': '지금 가장 필요한 것은 무엇인가요?',
+          'options': [
+            {'text': '혼자만의 시간과 휴식', 'score': 3},
+            {'text': '누군가와 대화', 'score': 3},
+            {'text': '전문가 상담', 'score': 1},
+            {'text': '잘 모르겠어요', 'score': 2},
+          ]
+        },
+      ];
+    } else if (widget.moodScore >= 4 && widget.moodScore <= 6) {
+      // 보통 기분 (4-6점)
+      return [
+        {
+          'id': 'neutral_feeling',
+          'question': '오늘 하루의 전반적인 느낌은 어땠나요?',
+          'options': [
+            {'text': '평범하고 무난했어요', 'score': 3},
+            {'text': '약간 지루했어요', 'score': 2},
+            {'text': '그럭저럭 괜찮았어요', 'score': 4},
+            {'text': '기복이 있었어요', 'score': 2},
+          ]
+        },
+        {
+          'id': 'neutral_energy',
+          'question': '현재 에너지 레벨은 어떤가요?',
+          'options': [
+            {'text': '무기력함', 'score': 1},
+            {'text': '피곤함', 'score': 2},
+            {'text': '보통', 'score': 3},
+            {'text': '활기참', 'score': 4},
+          ]
+        },
+        {
+          'id': 'neutral_social',
+          'question': '오늘 다른 사람들과의 교류는 어땠나요?',
+          'options': [
+            {'text': '사람을 만나고 싶지 않았어요', 'score': 1},
+            {'text': '필요한 만큼만 했어요', 'score': 3},
+            {'text': '즐겁게 대화했어요', 'score': 4},
+            {'text': '특별한 교류가 없었어요', 'score': 2},
+          ]
+        },
+      ];
+    } else {
+      // 긍정적인 기분 (7-10점)
+      return [
+        {
+          'id': 'positive_reason',
+          'question': '오늘 기분이 좋은 이유는 무엇인가요?',
+          'options': [
+            {'text': '좋은 소식이 있었어요', 'score': 4},
+            {'text': '즐거운 활동을 했어요', 'score': 4},
+            {'text': '편안한 휴식을 취했어요', 'score': 3},
+            {'text': '특별한 이유 없이 좋아요', 'score': 4},
+          ]
+        },
+        {
+          'id': 'positive_energy',
+          'question': '현재 에너지 레벨은 어떤가요?',
+          'options': [
+            {'text': '매우 활기차요', 'score': 4},
+            {'text': '적당히 활동적이에요', 'score': 3},
+            {'text': '편안하고 만족스러워요', 'score': 4},
+            {'text': '행복하지만 조금 피곤해요', 'score': 3},
+          ]
+        },
+        {
+          'id': 'positive_share',
+          'question': '이 좋은 기분을 유지하기 위해 무엇을 하고 싶나요?',
+          'options': [
+            {'text': '취미 활동 하기', 'score': 4},
+            {'text': '좋아하는 사람과 시간 보내기', 'score': 4},
+            {'text': '새로운 것에 도전하기', 'score': 4},
+            {'text': '그냥 이대로 즐기기', 'score': 3},
+          ]
+        },
+      ];
+    }
+  }
+
+  String _getMoodCategory() {
+    if (widget.moodScore >= 1 && widget.moodScore <= 3) {
+      return '힘든 하루';
+    } else if (widget.moodScore >= 4 && widget.moodScore <= 6) {
+      return '평범한 하루';
+    } else {
+      return '좋은 하루';
+    }
+  }
+
+  IconData _getMoodIcon() {
+    if (widget.moodScore >= 1 && widget.moodScore <= 3) {
+      return Icons.sentiment_very_dissatisfied;
+    } else if (widget.moodScore >= 4 && widget.moodScore <= 6) {
+      return Icons.sentiment_neutral;
+    } else {
+      return Icons.sentiment_very_satisfied;
+    }
+  }
+
+  Color _getMoodColor() {
+    if (widget.moodScore >= 1 && widget.moodScore <= 3) {
+      return Colors.red[400]!;
+    } else if (widget.moodScore >= 4 && widget.moodScore <= 6) {
+      return Colors.orange[400]!;
+    } else {
+      return Colors.green[400]!;
+    }
+  }
+
+  Future<void> _submitAnswers() async {
+    // 모든 질문에 답변했는지 확인
+    final questions = _getQuestions();
+    for (var question in questions) {
+      if (_answers[question['id']] == null) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('모든 질문에 답변해주세요.')),
+        );
+        return;
+      }
+    }
+
+    setState(() {
+      _isSubmitting = true;
+    });
+
+    try {
+      // 총 점수 계산
+      int totalScore = 0;
+      _answers.forEach((key, value) {
+        totalScore += (value['score'] as int);
+      });
+
+      // 평균 점수 계산 (선택지 점수는 1-4 사이)
+      double averageScore = totalScore / questions.length;
+
+      // Firestore에 저장할 데이터 준비
+      Map<String, String> answersForFirestore = {};
+      _answers.forEach((key, value) {
+        answersForFirestore[key] = value['text'];
+      });
+
+      // Firestore에 기분 점수 및 상세 답변 저장
+      await _firestoreService.updateMoodScore(
+        widget.userId,
+        widget.moodScore,
+        detailedAnswers: answersForFirestore,
+        detailScore: averageScore, // 상세 질문 평균 점수
+      );
+
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('기분 분석이 저장되었습니다!')),
+        );
+        Navigator.pop(context); // 이전 화면으로 돌아가기
+      }
+    } catch (e) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('저장 중 오류가 발생했습니다: $e')),
+        );
+      }
+    } finally {
+      if (mounted) {
+        setState(() {
+          _isSubmitting = false;
+        });
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final questions = _getQuestions();
+
+    return Scaffold(
+      backgroundColor: const Color(0xFFF5F7FA),
+      appBar: AppBar(
+        title: Text(
+          '기분 분석',
+          style: GoogleFonts.roboto(
+            fontWeight: FontWeight.bold,
+            color: kColorTextTitle,
+          ),
+        ),
+        backgroundColor: Colors.white,
+        elevation: 0,
+        iconTheme: const IconThemeData(color: kColorTextTitle),
+      ),
+      body: SingleChildScrollView(
+        child: Padding(
+          padding: const EdgeInsets.all(20.0),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              // 기분 점수 카드
+              Card(
+                elevation: 2.0,
+                color: kColorCardBg,
+                shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(16.0),
+                ),
+                child: Padding(
+                  padding: const EdgeInsets.all(24.0),
+                  child: Column(
+                    children: [
+                      Icon(
+                        _getMoodIcon(),
+                        size: 64,
+                        color: _getMoodColor(),
+                      ),
+                      const SizedBox(height: 12),
+                      Text(
+                        _getMoodCategory(),
+                        style: GoogleFonts.roboto(
+                          fontSize: 24,
+                          fontWeight: FontWeight.bold,
+                          color: kColorTextTitle,
+                        ),
+                      ),
+                      const SizedBox(height: 8),
+                      Text(
+                        '기분 점수: ${widget.moodScore}/10',
+                        style: GoogleFonts.roboto(
+                          fontSize: 16,
+                          color: kColorTextSubtitle,
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+              const SizedBox(height: 24),
+
+              // 안내 텍스트
+              Text(
+                '몇 가지 질문에 답변해주시면\n더 정확한 분석이 가능합니다.',
+                textAlign: TextAlign.center,
+                style: GoogleFonts.roboto(
+                  fontSize: 14,
+                  color: kColorTextSubtitle,
+                  height: 1.5,
+                ),
+              ),
+              const SizedBox(height: 24),
+
+              // 질문 목록
+              ...questions.asMap().entries.map((entry) {
+                final index = entry.key;
+                final question = entry.value;
+                return Padding(
+                  padding: const EdgeInsets.only(bottom: 20.0),
+                  child: _buildQuestionCard(
+                    questionNumber: index + 1,
+                    questionId: question['id']!,
+                    questionText: question['question']!,
+                    options: question['options']! as List<Map<String, dynamic>>,
+                  ),
+                );
+              }).toList(),
+
+              const SizedBox(height: 24),
+
+              // 제출 버튼
+              ElevatedButton(
+                onPressed: _isSubmitting ? null : _submitAnswers,
+                style: ElevatedButton.styleFrom(
+                  backgroundColor: kColorBtnPrimary,
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(12.0),
+                  ),
+                  minimumSize: const Size(double.infinity, 50),
+                ),
+                child: _isSubmitting
+                    ? const SizedBox(
+                  height: 20,
+                  width: 20,
+                  child: CircularProgressIndicator(
+                    strokeWidth: 2,
+                    valueColor:
+                    AlwaysStoppedAnimation<Color>(Colors.white),
+                  ),
+                )
+                    : Text(
+                  '분석 완료',
+                  style: GoogleFonts.roboto(
+                    color: Colors.white,
+                    fontSize: 16,
+                    fontWeight: FontWeight.bold,
+                  ),
+                ),
+              ),
+              const SizedBox(height: 40),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildQuestionCard({
+    required int questionNumber,
+    required String questionId,
+    required String questionText,
+    required List<Map<String, dynamic>> options,
+  }) {
+    return Card(
+      elevation: 1.0,
+      color: kColorCardBg,
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(16.0),
+      ),
+      child: Padding(
+        padding: const EdgeInsets.all(20.0),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                Container(
+                  width: 28,
+                  height: 28,
+                  decoration: BoxDecoration(
+                    color: kColorBtnPrimary,
+                    shape: BoxShape.circle,
+                  ),
+                  child: Center(
+                    child: Text(
+                      '$questionNumber',
+                      style: GoogleFonts.roboto(
+                        color: Colors.white,
+                        fontSize: 14,
+                        fontWeight: FontWeight.bold,
+                      ),
+                    ),
+                  ),
+                ),
+                const SizedBox(width: 12),
+                Expanded(
+                  child: Text(
+                    questionText,
+                    style: GoogleFonts.roboto(
+                      fontSize: 15,
+                      fontWeight: FontWeight.w600,
+                      color: kColorTextTitle,
+                    ),
+                  ),
+                ),
+              ],
+            ),
+            const SizedBox(height: 16),
+
+            // 객관식 선택지들
+            ...options.map((option) {
+              final isSelected = _answers[questionId]?['text'] == option['text'];
+
+              return Padding(
+                padding: const EdgeInsets.only(bottom: 10.0),
+                child: InkWell(
+                  onTap: () {
+                    setState(() {
+                      _answers[questionId] = {
+                        'text': option['text'],
+                        'score': option['score'],
+                      };
+                    });
+                  },
+                  borderRadius: BorderRadius.circular(12.0),
+                  child: Container(
+                    padding: const EdgeInsets.all(16.0),
+                    decoration: BoxDecoration(
+                      color: isSelected
+                          ? kColorBtnPrimary.withOpacity(0.1)
+                          : const Color(0xFFF5F7FA),
+                      border: Border.all(
+                        color: isSelected
+                            ? kColorBtnPrimary
+                            : Colors.transparent,
+                        width: 2,
+                      ),
+                      borderRadius: BorderRadius.circular(12.0),
+                    ),
+                    child: Row(
+                      children: [
+                        Container(
+                          width: 20,
+                          height: 20,
+                          decoration: BoxDecoration(
+                            shape: BoxShape.circle,
+                            border: Border.all(
+                              color: isSelected
+                                  ? kColorBtnPrimary
+                                  : kColorTextSubtitle.withOpacity(0.3),
+                              width: 2,
+                            ),
+                            color: isSelected
+                                ? kColorBtnPrimary
+                                : Colors.transparent,
+                          ),
+                          child: isSelected
+                              ? const Icon(
+                            Icons.check,
+                            size: 14,
+                            color: Colors.white,
+                          )
+                              : null,
+                        ),
+                        const SizedBox(width: 12),
+                        Expanded(
+                          child: Text(
+                            option['text'],
+                            style: GoogleFonts.roboto(
+                              fontSize: 14,
+                              color: isSelected
+                                  ? kColorBtnPrimary
+                                  : kColorTextTitle,
+                              fontWeight: isSelected
+                                  ? FontWeight.w600
+                                  : FontWeight.normal,
+                            ),
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                ),
+              );
+            }).toList(),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/services/firestore_service.dart
+++ b/lib/services/firestore_service.dart
@@ -28,11 +28,37 @@ class FirestoreService {
   }
 
   // Update user mood score
-  Future<void> updateMoodScore(String uid, int moodScore) async {
-    await _db.collection('users').doc(uid).collection('mood_scores').add({
-      'score': moodScore,
-      'timestamp': FieldValue.serverTimestamp(),
-    });
+  Future<void> updateMoodScore(
+      String userId,
+      int score, {
+        Map<String, String>? detailedAnswers,
+        double? detailScore,  // 상세 질문의 평균 점수 추가
+      }) async {
+    try {
+      final data = {
+        'score': score,
+        'timestamp': FieldValue.serverTimestamp(),
+      };
+
+      // 상세 답변이 있으면 포함
+      if (detailedAnswers != null && detailedAnswers.isNotEmpty) {
+        data['detailedAnswers'] = detailedAnswers;
+      }
+
+      // 상세 질문 점수가 있으면 포함
+      if (detailScore != null) {
+        data['detailScore'] = detailScore;
+      }
+
+      await _db
+          .collection('users')
+          .doc(userId)
+          .collection('moodScores')
+          .add(data);
+    } catch (e) {
+      print('Error updating mood score: $e');
+      rethrow;
+    }
   }
 
   // Get user mood scores

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -396,10 +396,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
+      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.16.0"
   path:
     dependency: transitive
     description:
@@ -577,10 +577,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
+      sha256: "522f00f556e73044315fa4585ec3270f1808a4b186c936e612cab0b565ff1e00"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.7"
+    version: "0.7.6"
   typed_data:
     dependency: transitive
     description:


### PR DESCRIPTION
## 주요 구현 사항

### 1. 기분 분석 플로우
- **main_screen.dart**: 슬라이더로 기분 선택 (1-10) → 분석하기 버튼 활성화
- **mood_detail_questions_screen.dart**: 기분 점수 범위별 맞춤 질문 제공
  - 1-3점 (부정적): 4개 질문
  - 4-6점 (보통): 3개 질문  
  - 7-10점 (긍정적): 3개 질문

### 2. 점수 시스템 설계 (카테고리 + 정도 분리)

**카테고리형 질문** (`type: 'category'`)
- 점수 계산에 포함하지 않음
- 스트레스 요인, 긍정 요인 등의 **패턴 분석용 태그**로 활용
- 예: "기분이 좋지 않은 이유는?" → `work`, `relationship`, `health` 등

**정도형 질문** (`type: 'score'`)
- 실제 점수 계산에 사용 (1-4점)
- 심각도, 지속 기간, 일상생활 지장 정도 등 **측정 가능한 항목**
- 1점: 가장 부정적/심각 → 4점: 긍정적/양호

### 3. 데이터 저장 구조

**Firestore 경로**: `users/{userId}/moodScores/{docId}`
```javascript
{
  "score": 3,                    // 슬라이더 선택 점수 (1-10)
  "timestamp": Timestamp,        // 저장 시간
  "detailedAnswers": {           // 선택한 답변 텍스트
    "negative_reason": "업무/학업 스트레스",
    "negative_severity": "꽤 심각함",
    ...
  },
  "detailScore": 2.25,          // 정도형 질문들의 평균 점수 (1-4)
  "categories": {                // 카테고리형 질문 태그
    "negative_reason": "work"
  }
}
```

### 4. UI/UX 개선
- 객관식 선택지: 라디오 버튼 스타일의 단일 선택
- 선택한 항목 시각적 강조 (보라색 테두리 + 체크 아이콘)
- 모든 질문 답변 필수 검증
- 제출 중 로딩 상태 표시

## 추가/수정 파일

### 추가
- `lib/mood_detail_questions_screen.dart`: 상세 질문 화면

### 수정
- `lib/main_screen.dart`: 
  - 슬라이더 선택 상태 추적 (`_isMoodSelected`)
  - 버튼 활성화 로직 추가
  - 상세 질문 화면으로 네비게이션
  
- `lib/services/firestore_service.dart`:
  - `updateMoodScore()` 메서드에 선택적 매개변수 추가
    - `detailedAnswers`: 상세 답변 Map
    - `detailScore`: 정도형 질문 평균 점수
    - `categories`: 카테고리형 질문 태그 Map

## 향후 활용 계획
1. **정신 건강 점수 산출**: `score` + `detailScore` 조합하여 종합 점수 계산
2. **패턴 분석**: `categories` 데이터로 주요 스트레스 요인 파악
3. **개인화 추천**: 패턴 기반 맞춤형 힐링 콘텐츠 제공
4. **비상 알림**: 지속적인 저점수 감지 시 비상 연락처 알림

https://github.com/user-attachments/assets/a2ec1057-6938-49ca-b3c0-07382f180a3c

